### PR TITLE
OPSEXP-2174 Support next development release

### DIFF
--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -332,16 +332,17 @@ targets:
   {{- end }}
   {{- if index . "search-enterprise" }}
   {{- if index . "search-enterprise" "compose_target" }}
-  searchEnterpriseCompose_{{ $id }}:
+  {{- range $index, $key := index . "search-enterprise" "compose_keys" }}
+  searchEnterprise{{ $index }}Compose_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
     sourceid: searchEnterpriseTag_{{ $id }}
     transformers:
-      - addprefix: "quay.io/alfresco/alfresco-elasticsearch-live-indexing:"
+      - addprefix: "quay.io/alfresco/alfresco-elasticsearch-{{ $index }}:"
     spec:
       file: {{ index . "search-enterprise" "compose_target" }}
-      key: >-
-        {{ index . "search-enterprise" "compose_key" }}
+      key: {{ $key }}
+  {{- end }}
   {{- end }}
   {{- if index . "search-enterprise" "helm_target" }}
   {{- $target_searchEnt := index . "search-enterprise" "helm_target" }}

--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -331,7 +331,8 @@ targets:
   {{- end }}
   {{- end }}
   {{- if index . "search-enterprise" }}
-  {{- if index . "search-enterprise" "compose_target" }}
+  {{- $target_searchEntCompose := index . "search-enterprise" "compose_target" }}
+  {{- if $target_searchEntCompose }}
   {{- range $index, $key := index . "search-enterprise" "compose_keys" }}
   searchEnterprise{{ $index }}Compose_{{ $id }}:
     name: Search Enterprise image tag
@@ -340,7 +341,7 @@ targets:
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-elasticsearch-{{ $index }}:"
     spec:
-      file: {{ index . "search-enterprise" "compose_target" }}
+      file: {{ $target_searchEntCompose }}
       key: {{ $key }}
   {{- end }}
   {{- end }}

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -6,6 +6,7 @@ patterns:
   ga: &ga_pattern (\.[0-9]+){1,2}
   ga_with_hotfixes: &ga_hotfixes_pattern (\.[0-9]+){0,3}
   development: &development_pattern (\.[0-9]+){0,3}(-[AM]\.?[0-9]+)?
+  development_almost_semver_pattern: &development_almost_semver_pattern (\.[0-9]+){0,3}(-[0-9]+)?
 matrix:
   next:
     id: 231n

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -97,6 +97,8 @@ matrix:
       version: "~3.0.0"
     sfs:
       version: "~3.0.0"
+    tengine-aio:
+      version: "~4.0.0"
     tengine-misc:
       version: "~4.0.0"
     tengine-im:
@@ -146,6 +148,8 @@ matrix:
       version: "~2.0.0"
     sfs:
       version: "~2.0.0"
+    tengine-aio:
+      version: "~3.0.0"
     tengine-misc:
       version: "~3.0.0"
     tengine-im:
@@ -195,6 +199,8 @@ matrix:
       version: "~2.0.0"
     sfs:
       version: "~2.0.0"
+    tengine-aio:
+      version: "~2.5.0"
     tengine-misc:
       version: "~2.5.0"
     tengine-im:
@@ -241,6 +247,8 @@ matrix:
       version: "~1.5.0"
     sfs:
       version: "~1.5.0"
+    tengine-aio:
+      version: "~2.5.0"
     tengine-misc:
       version: "~2.5.0"
     tengine-im:
@@ -281,6 +289,8 @@ matrix:
       version: "~1.4.0"
     sfs:
       version: "~0.16.0"
+    tengine-aio:
+      version: "~2.5.0"
     tengine-misc:
       version: "~2.5.0"
     tengine-im:

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -59,7 +59,7 @@ matrix:
     tengine-tika:
       version: ">=3.1.0-0"
 
-  latest:
+  7.4.N:
     id: 74n
     acs:
       version: "7.4"

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -7,16 +7,67 @@ patterns:
   ga_with_hotfixes: &ga_hotfixes_pattern (\.[0-9]+){0,3}
   development: &development_pattern (\.[0-9]+){0,3}(-[AM]\.?[0-9]+)?
 matrix:
+  next:
+    id: 231n
+    acs:
+      version: "23.1"
+      pattern: *development_pattern
+      image: &repository_image quay.io/alfresco/alfresco-content-repository
+    share:
+      version: "23.1"
+      pattern: *development_pattern
+      image: &share_image quay.io/alfresco/alfresco-share
+    search:
+      version: "2"
+      image: quay.io/alfresco/search-services
+      pattern: *development_pattern
+    search-enterprise:
+      version: "3"
+      pattern: *development_pattern
+    sync:
+      version: "4"
+      pattern: *development_pattern
+    adw:
+      version: "4.1"
+      pattern: *development_almost_semver_pattern
+    adminApp:
+      version: "8.1"
+      pattern: *development_almost_semver_pattern
+    onedrive:
+      version: "2"
+      pattern: *development_pattern
+    msteams:
+      version: "2"
+      pattern: *development_pattern
+    intelligence:
+      version: ">=1.5.0-0"
+    trouter:
+      version: ">=2.1.0-0"
+    sfs:
+      version: ">=2.1.0-0"
+    tengine-aio:
+      version: ">=3.1.0-0"
+    tengine-misc:
+      version: ">=3.1.0-0"
+    tengine-im:
+      version: ">=3.1.0-0"
+    tengine-lo:
+      version: ">=3.1.0-0"
+    tengine-pdf:
+      version: ">=3.1.0-0"
+    tengine-tika:
+      version: ">=3.1.0-0"
+
   latest:
     id: 74n
     acs:
       version: "7.4"
       pattern: *ga_hotfixes_pattern
-      image: &repository_image quay.io/alfresco/alfresco-content-repository
+      image: *repository_image
     share:
       version: "7.4"
       pattern: *ga_hotfixes_pattern
-      image: &share_image quay.io/alfresco/alfresco-share
+      image: *share_image
     search:
       version: "2.0.7"
       image: quay.io/alfresco/search-services


### PR DESCRIPTION
Ref: OPSEXP-2174

* Fixup tengine-aio that for some reason was missing
* Rename latest section to 7.4.N to uniform with the others
* support multiple target keys also for search enterprise compose