### PR TITLE
OPSEXP-1861: skip sfs & trouter compose if no matching keys in values

### DIFF
--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -416,6 +416,8 @@ targets:
         {{ .intelligence.helm_key }}
   {{- end }}
   {{- if index . "trouter" }}
+  {{- with .trouter }}
+  {{- if and .compose_key .compose_target }}
   trouterCompose_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
@@ -423,9 +425,11 @@ targets:
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-transform-router:"
     spec:
-      file: {{ index . "trouter" "compose_target" }}
+      file: {{ .compose_target }}
       key: >-
-        {{ index . "trouter" "compose_key" }}
+        {{ .compose_key }}
+  {{- end }}
+  {{- end }}
   trouterValues_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
@@ -436,6 +440,8 @@ targets:
         {{ .trouter.helm_key }}
   {{- end }}
   {{- if index . "sfs" }}
+  {{- with .sfs }}
+  {{- if and .compose_key .compose_target }}
   sfsCompose_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml
@@ -443,9 +449,11 @@ targets:
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-shared-file-store:"
     spec:
-      file: {{ index . "sfs" "compose_target" }}
+      file: {{ .compose_target }}
       key: >-
-        {{ index . "sfs" "compose_key" }}
+        {{ .compose_key }}
+  {{- end }}
+  {{- end }}
   sfsValues_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml


### PR DESCRIPTION
Ref: OPSEXP-1861

Needed to integration updatecli pipelines in alfresco-helm-charts without breaking on missing compose files:

tested the resulting pipeline locally:

```bash
REPORTS:


✔ UBER-MANIFEST.TPL:
        Source:
                ✔ [intelligenceTag_74n] Intelligence Service image tag
                ✔ [msteamsTag_74n] MS Teams Service image tag
                ✔ [onedriveTag_74n] Onedrive (OOI) Service image tag
                ✔ [searchEnterpriseTag_74n] Search Enterprise tag
                ✔ [searchTag_74n] Alfresco Search Services
                ✔ [sfsTag_74n] Alfresco Shared Filestore image tag
                ✔ [syncTag_74n] Sync Service image tag
                ✔ [tengine-imTag_74n] Alfresco ImageMagick Transform Engine image tag
                ✔ [tengine-loTag_74n] Alfresco LibreOffice Transform Engine image tag
                ✔ [tengine-miscTag_74n] Alfresco misc Transform Engine image tag
                ✔ [tengine-pdfTag_74n] Alfresco PDF Transform Engine image tag
                ✔ [tengine-tikaTag_74n] Alfresco tika Transform Engine image tag
                ✔ [trouterTag_74n] Alfresco Transform Router image tag
        Target:
                ✔ [intelligenceValues_74n] Alfresco Intelligence image tag
                ✔ [msteamsValues_74n] MS Teams image tag
                ✔ [onedriveValues_74n] Onedrive image tag
                ✔ [searchEnterpriseContentValues_74n] Search Enterprise image tag
                ✔ [searchEnterpriseMediationValues_74n] Search Enterprise image tag
                ✔ [searchEnterpriseMetadataValues_74n] Search Enterprise image tag
                ✔ [searchEnterprisePathValues_74n] Search Enterprise image tag
                ✔ [searchEnterpriseReindexingValues_74n] Search Enterprise image tag
                ✔ [sfsValues_74n] Alfresco Shared Filestore image tag
                ✔ [syncValues_74n] Sync image tag
                ✔ [tengine-imValues_74n] Alfresco ImageMagick Transform Engine image tag
                ✔ [tengine-loValues_74n] Alfresco LibreOffice Transform Engine image tag
                ✔ [tengine-miscValues_74n] Alfresco misc Transform Engine image tag
                ✔ [tengine-pdfValues_74n] Alfresco PDF Transform Engine image tag
                ✔ [tengine-tikaValues_74n] Alfresco tika Transform Engine image tag
                ✔ [trouterValues_74n] Alfresco Transform Router image tag


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
```