### PR TITLE
OPSEXP-2364 Bump supported matrix for acs 23.1 release

### DIFF
--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -58,7 +58,7 @@ sources:
           ^{{ index . "aca" "version" }}{{ index . "aca" "pattern" }}$
   {{- end }}
   {{- if index . "acs" }}
-  {{ $repo_image := index . "acs" "image" }}
+  {{ $repo_image := index . "acs" "image" | default "quay.io/alfresco/alfresco-content-repository" }}
   repositoryTag_{{ $id }}:
     name: ACS repository tag
     kind: dockerimage
@@ -84,7 +84,7 @@ sources:
           ^{{ index . "search-enterprise" "version" }}{{ index . "search-enterprise" "pattern" }}$
   {{ end }}
   {{- if index . "search" }}
-  {{ $search_image := index . "search" "image" }}
+  {{ $search_image := index . "search" "image" | default "quay.io/alfresco/search-services" }}
   searchTag_{{ $id }}:
     name: Alfresco Search Services
     kind: dockerimage
@@ -99,7 +99,7 @@ sources:
           ^{{ index . "search" "version" }}{{ index . "search" "pattern" }}$
   {{- end }}
   {{- if index . "share" }}
-  {{ $share_image := index . "share" "image" }}
+  {{ $share_image := index . "share" "image" | default "quay.io/alfresco/alfresco-share" }}
   shareTag_{{ $id }}:
     name: Share repository tag
     kind: dockerimage

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -64,11 +64,11 @@ matrix:
     acs:
       version: "23.1"
       pattern: *ga_hotfixes_pattern
-      image: &repository_image quay.io/alfresco/alfresco-content-repository
+      image: quay.io/alfresco/alfresco-content-repository
     share:
       version: "23.1"
       pattern: *ga_hotfixes_pattern
-      image: &share_image quay.io/alfresco/alfresco-share
+      image: quay.io/alfresco/alfresco-share
     search:
       version: &search_ga_version "2.0.8"
       image: quay.io/alfresco/search-services

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -1,7 +1,6 @@
 ---
 # Reflection of https://docs.alfresco.com/content-services/latest/support/
 # TO BE ENRICHED AS RELEASES ARE OUT
-# yaml-language-server: $schema=./supported-matrix.yaml
 patterns:
   ga: &ga_pattern (\.[0-9]+){1,2}
   ga_with_hotfixes: &ga_hotfixes_pattern (\.[0-9]+){0,3}

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -12,14 +12,11 @@ matrix:
     acs:
       version: "23.2"
       pattern: *development_pattern
-      image: &repository_image quay.io/alfresco/alfresco-content-repository
     share:
       version: "23.2"
       pattern: *development_pattern
-      image: &share_image quay.io/alfresco/alfresco-share
     search:
       version: "2"
-      image: quay.io/alfresco/search-services
       pattern: *development_pattern
     search-enterprise:
       version: "4"
@@ -63,14 +60,11 @@ matrix:
     acs:
       version: "23.1"
       pattern: *ga_hotfixes_pattern
-      image: quay.io/alfresco/alfresco-content-repository
     share:
       version: "23.1"
       pattern: *ga_hotfixes_pattern
-      image: quay.io/alfresco/alfresco-share
     search:
       version: &search_ga_version "2.0.8"
-      image: quay.io/alfresco/search-services
       pattern: *ga_hotfixes_pattern
     search-enterprise:
       version: "4.0"
@@ -114,14 +108,11 @@ matrix:
     acs:
       version: &acs_ga_version "7.4"
       pattern: *ga_hotfixes_pattern
-      image: *repository_image
     share:
       version: *acs_ga_version
       pattern: *ga_hotfixes_pattern
-      image: *share_image
     search:
       version: "2.0.8"
-      image: quay.io/alfresco/search-services
       pattern: *ga_hotfixes_pattern
     search-enterprise:
       version: "3.3"
@@ -165,15 +156,12 @@ matrix:
     acs:
       version: "7.3.1"
       pattern: *ga_hotfixes_pattern
-      image: *repository_image
     share:
       version: "7.3.1"
       pattern: *ga_hotfixes_pattern
-      image: *share_image
     search:
       version: "2.0.5"
       pattern: *ga_hotfixes_pattern
-      image: quay.io/alfresco/search-services
     search-enterprise:
       version: "3.2"
       pattern: *ga_hotfixes_pattern
@@ -216,15 +204,12 @@ matrix:
     acs:
       version: "7.2"
       pattern: *ga_hotfixes_pattern
-      image: *repository_image
     share:
       version: "7.2"
       pattern: *ga_hotfixes_pattern
-      image: *share_image
     search:
       version: "2.0.3"
       pattern: *ga_hotfixes_pattern
-      image: quay.io/alfresco/search-services
     search-enterprise:
       version: "3.1"
       pattern: *ga_hotfixes_pattern
@@ -267,15 +252,12 @@ matrix:
     acs:
       version: "7.1"
       pattern: *ga_hotfixes_pattern
-      image: *repository_image
     share:
       version: "7.1"
       pattern: *ga_hotfixes_pattern
-      image: *share_image
     search:
       version: "2.0.2"
       pattern: *ga_hotfixes_pattern
-      image: quay.io/alfresco/search-services
     search-enterprise:
       version: "3.1"
       pattern: *ga_hotfixes_pattern
@@ -315,15 +297,12 @@ matrix:
     acs:
       version: "7.0"
       pattern: *ga_hotfixes_pattern
-      image: *repository_image
     share:
       version: "7.0"
       pattern: *ga_hotfixes_pattern
-      image: *share_image
     search:
       version: "2.0.2"
       pattern: *ga_hotfixes_pattern
-      image: quay.io/alfresco/search-services
     sync:
       version: "3.7"
       pattern: *ga_hotfixes_pattern

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -8,7 +8,7 @@ patterns:
   development_almost_semver_pattern: &development_almost_semver_pattern (\.[0-9]+){0,3}(-[0-9]+)?
 matrix:
   next:
-    id: 232n
+    id: next
     acs:
       version: "23.2"
       pattern: *development_pattern

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -55,8 +55,8 @@ matrix:
     tengine-tika:
       version: ">=4.0.0-0"
 
-  23.1.N:
-    id: 231n
+  23.N:
+    id: 23n
     acs:
       version: "23.1"
       pattern: *ga_hotfixes_pattern

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -9,13 +9,13 @@ patterns:
   development_almost_semver_pattern: &development_almost_semver_pattern (\.[0-9]+){0,3}(-[0-9]+)?
 matrix:
   next:
-    id: 231n
+    id: 232n
     acs:
-      version: "23.1"
+      version: "23.2"
       pattern: *development_pattern
       image: &repository_image quay.io/alfresco/alfresco-content-repository
     share:
-      version: "23.1"
+      version: "23.2"
       pattern: *development_pattern
       image: &share_image quay.io/alfresco/alfresco-share
     search:
@@ -26,13 +26,13 @@ matrix:
       version: "4"
       pattern: *development_pattern
     sync:
-      version: "4"
+      version: "5"
       pattern: *development_pattern
     adw:
-      version: "4.2"
+      version: "4.4"
       pattern: *development_almost_semver_pattern
     adminApp:
-      version: "8.2"
+      version: "8.4"
       pattern: *development_almost_semver_pattern
     onedrive:
       version: "2"
@@ -41,23 +41,74 @@ matrix:
       version: "2"
       pattern: *development_pattern
     intelligence:
-      version: ">=1.5.0-0"
+      version: ">=3.0.0-0"
     trouter:
-      version: ">=2.1.0-0"
+      version: ">=4.0.0-0"
     sfs:
-      version: ">=2.1.0-0"
+      version: ">=4.0.0-0"
     tengine-aio:
-      version: ">=3.1.0-0"
+      version: ">=4.0.0-0"
     tengine-misc:
-      version: ">=3.1.0-0"
+      version: ">=4.0.0-0"
     tengine-im:
-      version: ">=3.1.0-0"
+      version: ">=4.0.0-0"
     tengine-lo:
-      version: ">=3.1.0-0"
+      version: ">=4.0.0-0"
     tengine-pdf:
-      version: ">=3.1.0-0"
+      version: ">=4.0.0-0"
     tengine-tika:
-      version: ">=3.1.0-0"
+      version: ">=4.0.0-0"
+
+  23.1.N:
+    id: 231n
+    acs:
+      version: "23.1"
+      pattern: *ga_hotfixes_pattern
+      image: &repository_image quay.io/alfresco/alfresco-content-repository
+    share:
+      version: "23.1"
+      pattern: *ga_hotfixes_pattern
+      image: &share_image quay.io/alfresco/alfresco-share
+    search:
+      version: &search_ga_version "2.0.8"
+      image: quay.io/alfresco/search-services
+      pattern: *ga_hotfixes_pattern
+    search-enterprise:
+      version: "4.0"
+      pattern: *ga_hotfixes_pattern
+    sync:
+      version: "4.0"
+      pattern: *ga_hotfixes_pattern
+    adw:
+      version: "4.3"
+      pattern: *ga_hotfixes_pattern
+    adminApp:
+      version: "8.3"
+      pattern: *ga_hotfixes_pattern
+    onedrive:
+      version: "2"
+      pattern: *ga_hotfixes_pattern
+    msteams:
+      version: "2"
+      pattern: *ga_hotfixes_pattern
+    intelligence:
+      version: "~2.0.0"
+    trouter:
+      version: "~4.0.0"
+    sfs:
+      version: "~4.0.0"
+    tengine-aio:
+      version: &tengine_ga_version "~4.0.0"
+    tengine-misc:
+      version: "~4.0.0"
+    tengine-im:
+      version: "~4.0.0"
+    tengine-lo:
+      version: "~4.0.0"
+    tengine-pdf:
+      version: "~4.0.0"
+    tengine-tika:
+      version: "~4.0.0"
 
   7.4.N:
     id: 74n
@@ -70,7 +121,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: *share_image
     search:
-      version: &search_ga_version "2.0.8"
+      version: "2.0.8"
       image: quay.io/alfresco/search-services
       pattern: *ga_hotfixes_pattern
     search-enterprise:
@@ -98,7 +149,7 @@ matrix:
     sfs:
       version: "~3.0.0"
     tengine-aio:
-      version: &tengine_ga_version "~4.0.0"
+      version: "~4.0.0"
     tengine-misc:
       version: "~4.0.0"
     tengine-im:


### PR DESCRIPTION
Ref: OPSEXP-2364

Tested in https://github.com/Alfresco/alfresco-helm-charts/pull/148