### PR TITLE
OPSEXP-2365 Workaround for older releases versions

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -265,8 +265,8 @@ matrix:
       version: "3.7"
       pattern: *ga_hotfixes_pattern
     adw:
-      version: "2.6"
-      pattern: *ga_pattern
+      version: "2.6.2"
+      pattern: ""
     onedrive:
       version: "1.1.1"
       pattern: *ga_hotfixes_pattern
@@ -307,8 +307,8 @@ matrix:
       version: "3.7"
       pattern: *ga_hotfixes_pattern
     adw:
-      version: "2.6"
-      pattern: *ga_pattern
+      version: "2.6.2"
+      pattern: ""
     onedrive:
       version: "1.1.0"
       pattern: *ga_hotfixes_pattern

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -250,10 +250,10 @@ matrix:
   7.1.N:
     id: 71n
     acs:
-      version: "7.1"
+      version: "7.1.1"
       pattern: *ga_hotfixes_pattern
     share:
-      version: "7.1"
+      version: "7.1.1"
       pattern: *ga_hotfixes_pattern
     search:
       version: "2.0.2"


### PR DESCRIPTION
Ref: OPSEXP-2365

It's the simpler workaround I can think of and didn't want to bother since those versions are going to get deprecated soon, but the root cause really is that we are using regexp filters because most tags are not really semver compliant, and quay is returning tags sorted by creation date, hence we get this weird behaviour.

When running updatecli workflow I get:
<img width="656" alt="Screenshot 2023-11-09 at 12 08 54" src="https://github.com/Alfresco/alfresco-updatecli/assets/71768/4252f9ea-d897-4a11-bf88-03e851aecbf7">

