### PR TITLE
OPSEXP-2404 Fixup ATS/Sync matrix for ACS 7.3, 7.2 to fix CVE-2023-46604

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -166,7 +166,7 @@ matrix:
       version: "3.2"
       pattern: *ga_hotfixes_pattern
     sync:
-      version: "3.8"
+      version: "3.10"
       pattern: *ga_hotfixes_pattern
     adw:
       version: "3.1"
@@ -214,7 +214,7 @@ matrix:
       version: "3.1.1"
       pattern: *ga_hotfixes_pattern
     sync:
-      version: "3.8"
+      version: "3.10"
       pattern: *ga_hotfixes_pattern
     adw:
       version: "3.0"

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -183,21 +183,21 @@ matrix:
     intelligence:
       version: "~1.5.0"
     trouter:
-      version: "~2.0.0"
+      version: "~2.1.1"
     sfs:
-      version: "~2.0.0"
+      version: "~2.1.1"
     tengine-aio:
-      version: "~3.0.0"
+      version: "~3.1.1"
     tengine-misc:
-      version: "~3.0.0"
+      version: "~3.1.1"
     tengine-im:
-      version: "~3.0.0"
+      version: "~3.1.1"
     tengine-lo:
-      version: "~3.0.0"
+      version: "~3.1.1"
     tengine-pdf:
-      version: "~3.0.0"
+      version: "~3.1.1"
     tengine-tika:
-      version: "~3.0.0"
+      version: "~3.1.1"
 
   7.2.N:
     id: 72n
@@ -231,21 +231,21 @@ matrix:
     intelligence:
       version: "~1.5.0"
     trouter:
-      version: "~2.0.0"
+      version: "~2.1.1"
     sfs:
-      version: "~2.0.0"
+      version: "~2.1.1"
     tengine-aio:
-      version: "~2.5.0"
+      version: "~3.1.1"
     tengine-misc:
-      version: "~2.5.0"
+      version: "~3.1.1"
     tengine-im:
-      version: "~2.5.0"
+      version: "~3.1.1"
     tengine-lo:
-      version: "~2.5.0"
+      version: "~3.1.1"
     tengine-pdf:
-      version: "~2.5.0"
+      version: "~3.1.1"
     tengine-tika:
-      version: "~2.5.0"
+      version: "~3.1.1"
 
   7.1.N:
     id: 71n


### PR DESCRIPTION
Ref: OPSEXP-2404

Tested in https://github.com/Alfresco/acs-deployment/pull/1051