### PR TITLE
OPSEXP-2403 Bump sync service matrix to fix CVE-2023-46604

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -166,7 +166,7 @@ matrix:
       version: "3.2"
       pattern: *ga_hotfixes_pattern
     sync:
-      version: "3.10"
+      version: "3.11"
       pattern: *ga_hotfixes_pattern
     adw:
       version: "3.1"
@@ -214,7 +214,7 @@ matrix:
       version: "3.1.1"
       pattern: *ga_hotfixes_pattern
     sync:
-      version: "3.10"
+      version: "3.11"
       pattern: *ga_hotfixes_pattern
     adw:
       version: "3.0"
@@ -262,7 +262,7 @@ matrix:
       version: "3.1.1"
       pattern: *ga_hotfixes_pattern
     sync:
-      version: "3.7"
+      version: "3.11"
       pattern: *ga_hotfixes_pattern
     adw:
       version: "2.6.2"


### PR DESCRIPTION
Ref: OPSEXP-2404