### PR TITLE
OPSEXP-2422 Bump intelligence for ACS 7.1 to fix CVE-2023-46604

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -181,7 +181,7 @@ matrix:
       version: "1.1"
       pattern: *ga_hotfixes_pattern
     intelligence:
-      version: "~1.5.1"
+      version: "~1.5.0"
     trouter:
       version: "~2.1.1"
     sfs:
@@ -229,7 +229,7 @@ matrix:
       version: "1.1"
       pattern: *ga_hotfixes_pattern
     intelligence:
-      version: "~1.5.1"
+      version: "~1.5.0"
     trouter:
       version: "~2.1.1"
     sfs:
@@ -274,7 +274,7 @@ matrix:
       version: "1.1"
       pattern: *ga_hotfixes_pattern
     intelligence:
-      version: "~1.5.1"
+      version: "~1.5.0"
     trouter:
       version: "~2.1.1"
     sfs:

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -181,7 +181,7 @@ matrix:
       version: "1.1"
       pattern: *ga_hotfixes_pattern
     intelligence:
-      version: "~1.5.0"
+      version: "~1.5.1"
     trouter:
       version: "~2.1.1"
     sfs:
@@ -229,7 +229,7 @@ matrix:
       version: "1.1"
       pattern: *ga_hotfixes_pattern
     intelligence:
-      version: "~1.5.0"
+      version: "~1.5.1"
     trouter:
       version: "~2.1.1"
     sfs:
@@ -274,7 +274,7 @@ matrix:
       version: "1.1"
       pattern: *ga_hotfixes_pattern
     intelligence:
-      version: "~1.4.0"
+      version: "~1.5.1"
     trouter:
       version: "~2.1.1"
     sfs:


### PR DESCRIPTION
Ref: OPSEXP-2422