### PR TITLE
OPSEXP-2651 Revert sync service 5.x bump due to repo image update not released yet

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -26,7 +26,7 @@ matrix:
       version: "4"
       pattern: *development_pattern
     sync:
-      version: "5"
+      version: "4" # see OPSEXP-2651 before bumping to 5.0
       pattern: *development_pattern
     adw:
       version: "4.5"
@@ -80,7 +80,7 @@ matrix:
       version: "4.0"
       pattern: *ga_hotfixes_pattern
     sync:
-      version: "5.0"
+      version: "4.0" # see OPSEXP-2651 before bumping to 5.0
       pattern: *ga_hotfixes_pattern
     adw:
       version: &adw_ga_version "4.4"


### PR DESCRIPTION
Ref: OPSEXP-2651

Latest repo images are still shipping 4.x sync AMP which is not compatible with 5.x sync