### PR TITLE
OPSEXP-2981: Reflect ATS supported matrix in 7.2 & 7.3 ACS versions & retire 7.1

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -221,21 +221,21 @@ matrix:
     intelligence:
       version: "~1.5.0"
     trouter:
-      version: "~4.1.1"
+      version: &ats_4_1 "~4.1.1"
     sfs:
-      version: "~4.1.1"
+      version: *ats_4_1
     tengine-aio:
-      version: "~5.1.1"
+      version: &tengine_5_1 "~5.1.1"
     tengine-misc:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-im:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-lo:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-pdf:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-tika:
-      version: "~5.1.1"
+      version: *tengine_5_1
     activiti:
       version: "2.4"
       pattern: *ga_hotfixes_pattern
@@ -281,21 +281,21 @@ matrix:
     intelligence:
       version: "~1.5.0"
     trouter:
-      version: "~4.1.1"
+      version: *ats_4_1
     sfs:
-      version: "~4.1.1"
+      version: *ats_4_1
     tengine-aio:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-misc:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-im:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-lo:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-pdf:
-      version: "~5.1.1"
+      version: *tengine_5_1
     tengine-tika:
-      version: "~5.1.1"
+      version: *tengine_5_1
     activiti:
       version: "2.4"
       pattern: *ga_hotfixes_pattern

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -303,57 +303,6 @@ matrix:
       version: "2.4"
       pattern: *ga_hotfixes_pattern
 
-  7.1.N:
-    id: 71n
-    acs:
-      version: "7.1.1"
-      pattern: *ga_hotfixes_pattern
-    activemq:
-      version: "5.16"
-      pattern: *ga_activemq_pattern
-    share:
-      version: "7.1.1"
-      pattern: *ga_hotfixes_pattern
-    insight-zeppelin:
-      version: *search_ga_version
-      pattern: *ga_hotfixes_pattern
-    search:
-      version: *search_ga_version
-      pattern: *ga_hotfixes_pattern
-    search-enterprise:
-      version: "3.1.1"
-      pattern: *ga_hotfixes_pattern
-    sync:
-      version: "3.11"
-      pattern: *ga_hotfixes_pattern
-    adw:
-      version: "4.4"
-      pattern: *ga_pattern
-    onedrive:
-      version: "1.1.1"
-      pattern: *ga_hotfixes_pattern
-    msteams:
-      version: "1.1"
-      pattern: *ga_hotfixes_pattern
-    intelligence:
-      version: "~1.5.0"
-    trouter:
-      version: "~2.1.1"
-    sfs:
-      version: "~2.1.1"
-    tengine-aio:
-      version: "~3.1.1"
-    tengine-misc:
-      version: "~3.1.1"
-    tengine-im:
-      version: "~3.1.1"
-    tengine-lo:
-      version: "~3.1.1"
-    tengine-pdf:
-      version: "~3.1.1"
-    tengine-tika:
-      version: "~3.1.1"
-
   community:
     id: com
     acs:

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -99,11 +99,11 @@ matrix:
     intelligence:
       version: &ais_ga_version "~3.1.0"
     trouter:
-      version: &ats_ga_version "~4.1.0"
+      version: &ats_ga_version "~4"
     sfs:
       version: *ats_ga_version
     tengine-aio:
-      version: &tengine_ga_version "~5.1.0"
+      version: &tengine_ga_version "~5"
     tengine-misc:
       version: *tengine_ga_version
     tengine-im:

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -99,9 +99,9 @@ matrix:
     intelligence:
       version: &ais_ga_version "~3.1.0"
     trouter:
-      version: &trouter_ga_version "~4.1.0"
+      version: &ats_ga_version "~4.1.0"
     sfs:
-      version: *trouter_ga_version
+      version: *ats_ga_version
     tengine-aio:
       version: &tengine_ga_version "~5.1.0"
     tengine-misc:
@@ -161,9 +161,9 @@ matrix:
     intelligence:
       version: *ais_ga_version
     trouter:
-      version: *trouter_ga_version
+      version: *ats_ga_version
     sfs:
-      version: *trouter_ga_version
+      version: *ats_ga_version
     tengine-aio:
       version: *tengine_ga_version
     tengine-misc:
@@ -221,21 +221,21 @@ matrix:
     intelligence:
       version: "~1.5.0"
     trouter:
-      version: "~2.1.1"
+      version: "~4.1.1"
     sfs:
-      version: "~2.1.1"
+      version: "~4.1.1"
     tengine-aio:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-misc:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-im:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-lo:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-pdf:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-tika:
-      version: "~3.1.1"
+      version: "~5.1.1"
     activiti:
       version: "2.4"
       pattern: *ga_hotfixes_pattern
@@ -281,21 +281,21 @@ matrix:
     intelligence:
       version: "~1.5.0"
     trouter:
-      version: "~2.1.1"
+      version: "~4.1.1"
     sfs:
-      version: "~2.1.1"
+      version: "~4.1.1"
     tengine-aio:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-misc:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-im:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-lo:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-pdf:
-      version: "~3.1.1"
+      version: "~5.1.1"
     tengine-tika:
-      version: "~3.1.1"
+      version: "~5.1.1"
     activiti:
       version: "2.4"
       pattern: *ga_hotfixes_pattern


### PR DESCRIPTION
Ref: OPSEXP-2981