### PR TITLE
OPSEXP-2989: move acs and share to semver for 'next' matrix

### DIFF
--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -79,8 +79,9 @@ sources:
         pattern: >-
           ^{{ index . "aca" "version" }}{{ index . "aca" "pattern" }}$
   {{- end }}
-  {{- if index . "acs" }}
-  {{ $repo_image := index . "acs" "image" | default $default_repo_image }}
+  {{- with .acs }}
+  {{- $vfk := .versionFilterKind | default "regex" }}
+  {{- $repo_image := .image | default $default_repo_image }}
   repositoryTag_{{ $id }}:
     name: ACS repository tag
     kind: dockerimage
@@ -90,12 +91,12 @@ sources:
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:
-        kind: {{ (eq $id "next") | ternary "semver" "regex" }}
+        kind: {{ $vfk }}
         pattern: >-
-          {{- if eq $id "next" }}
-          {{ index . "acs" "version" }}
+          {{- if eq $vfk "semver" }}
+          {{ .version }}
           {{- else }}
-          ^{{ index . "acs" "version" }}{{ index . "acs" "pattern" }}$
+          ^{{ .version }}{{ .pattern }}$
           {{- end }}
   {{- end }}
   {{ with index . "insight-zeppelin" }}
@@ -139,8 +140,9 @@ sources:
         pattern: >-
           ^{{ index . "search" "version" }}{{ index . "search" "pattern" }}$
   {{- end }}
-  {{- if index . "share" }}
-  {{ $share_image := index . "share" "image" | default $default_share_image }}
+  {{- with .share }}
+  {{- $vfk := .versionFilterKind | default "regex" }}
+  {{ $share_image := .image | default $default_share_image }}
   shareTag_{{ $id }}:
     name: Share repository tag
     kind: dockerimage
@@ -150,12 +152,12 @@ sources:
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:
-        kind: {{ (eq $id "next") | ternary "semver" "regex" }}
+        kind: {{ $vfk }}
         pattern: >-
-          {{- if eq $id "next" }}
-          {{ index . "share" "version" }}
+          {{- if eq $vfk "semver" }}
+          {{ .version }}
           {{- else }}
-          ^{{ index . "share" "version" }}{{ index . "share" "pattern" }}$
+          ^{{ .version }}{{ .pattern }}$
           {{- end }}
   {{- end }}
   {{- if index . "sync" }}

--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -90,9 +90,13 @@ sources:
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:
-        kind: regex
+        kind: {{ (eq $id "next") | ternary "semver" "regex" }}
         pattern: >-
+          {{- if eq $id "next" }}
+          {{ index . "acs" "version" }}
+          {{- else }}
           ^{{ index . "acs" "version" }}{{ index . "acs" "pattern" }}$
+          {{- end }}
   {{- end }}
   {{ with index . "insight-zeppelin" }}
   {{ $image := "quay.io/alfresco/insight-zeppelin" }}
@@ -146,9 +150,13 @@ sources:
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:
-        kind: regex
+        kind: {{ (eq $id "next") | ternary "semver" "regex" }}
         pattern: >-
+          {{- if eq $id "next" }}
+          {{ index . "share" "version" }}
+          {{- else }}
           ^{{ index . "share" "version" }}{{ index . "share" "pattern" }}$
+          {{- end }}
   {{- end }}
   {{- if index . "sync" }}
   syncTag_{{ $id }}:

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -10,13 +10,13 @@ patterns:
 matrix:
   next:
     id: next
-    acs:
-      version: &acs_next_version ">=25.0.0-0"
+    acs: &acs_next_version_spec
+      versionFilterKind: semver
+      version: ">=25.0.0-0"
     activemq:
       version: "5.18"
       pattern: *ga_activemq_pattern
-    share:
-      version: *acs_next_version
+    share: *acs_next_version_spec
     search:
       version: "2"
       pattern: *development_pattern

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -11,14 +11,12 @@ matrix:
   next:
     id: next
     acs:
-      version: &acs_next_version "23"
-      pattern: *development_pattern
+      version: &acs_next_version ">=25.0.0-0"
     activemq:
       version: "5.18"
       pattern: *ga_activemq_pattern
     share:
       version: *acs_next_version
-      pattern: *development_pattern
     search:
       version: "2"
       pattern: *development_pattern


### PR DESCRIPTION
Ref: OPSEXP-2989

Tested in https://github.com/Alfresco/acs-deployment/actions/runs/12280455809/job/34266917155