### PR TITLE
OPSEXP-3154 Skip sources when id is unset/falsy

### DIFF
--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -41,6 +41,7 @@ scms:
 
 sources:
   {{- range .matrix }}
+  {{- if .id }}
   {{- $id := .id -}}
   {{- with .adminApp }}
   adminAppTag_{{ $id }}:
@@ -262,6 +263,7 @@ sources:
       image: quay.io/alfresco/alfresco-audit-storage
       {{ template "quay_auth" }}
       {{ template "common_version_filter" . }}
+  {{- end }}
   {{- end }}
   {{- end }}
 


### PR DESCRIPTION
Sometimes we don't need to evaluate sources for all the supported versions, a possible approach could be to set the `.id` filter to null/false and skip the entire version sources.