### PR TITLE
OPSEXP-3218 Make alfresco-transform-core-aio image configurable

### DIFF
--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -194,7 +194,7 @@ sources:
     name: Alfresco All-In-One Transform Engine image tag
     kind: dockerimage
     spec:
-      image: alfresco/alfresco-transform-core-aio
+      image: quay.io/alfresco/alfresco-transform-core-aio
       {{ template "common_version_filter" . }}
   {{- end }}
   {{- with index . "tengine-misc" }}
@@ -673,7 +673,7 @@ targets:
     kind: yaml
     sourceid: tengine-aioTag_{{ $id }}
     transformers:
-      - addprefix: "alfresco/alfresco-transform-core-aio:"
+      - addprefix: "quay.io/alfresco/alfresco-transform-core-aio:"
     spec:
       file: {{ .compose_target }}
       key: >-

--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -38,6 +38,7 @@ scms:
 {{- $default_search_image := "quay.io/alfresco/search-services" }}
 {{- $default_share_image := "quay.io/alfresco/alfresco-share" }}
 {{- $default_activemq_image := "quay.io/alfresco/alfresco-activemq" }}
+{{- $default_aio_image := "quay.io/alfresco/alfresco-transform-core-aio" }}
 
 sources:
   {{- range .matrix }}
@@ -190,11 +191,15 @@ sources:
       {{ template "common_version_filter" . }}
   {{- end }}
   {{- with index . "tengine-aio" }}
+  {{ $aio_image := .image | default $default_aio_image }}
   tengine-aioTag_{{ $id }}:
     name: Alfresco All-In-One Transform Engine image tag
     kind: dockerimage
     spec:
-      image: quay.io/alfresco/alfresco-transform-core-aio
+      image: {{ $aio_image }}
+      {{ if eq (printf "%.8s" $aio_image) "quay.io/" }}
+      {{ template "quay_auth" }}
+      {{ end }}
       {{ template "common_version_filter" . }}
   {{- end }}
   {{- with index . "tengine-misc" }}
@@ -673,7 +678,7 @@ targets:
     kind: yaml
     sourceid: tengine-aioTag_{{ $id }}
     transformers:
-      - addprefix: "quay.io/alfresco/alfresco-transform-core-aio:"
+      - addprefix: "{{ .image | default $default_aio_image }}:"
     spec:
       file: {{ .compose_target }}
       key: >-


### PR DESCRIPTION
Ref: OPSEXP-3218

Because of: https://github.com/Alfresco/acs-deployment/pull/1300
Fix for: https://github.com/Alfresco/acs-deployment/pull/1357/commits/ee7267d479666e777d2883f5826cdbe844c404e3
tested on: https://github.com/Alfresco/acs-deployment/pull/1357/commits/7a4d35ba5df65c53901b868bbe60d800153a5c61
