### PR TITLE
OPSEXP-4102: Update search-enterprise version constraints to use semver

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -19,8 +19,8 @@ matrix:
       pattern: *ga_activemq_pattern
     share: *acs_next_version_spec
     search-enterprise:
-      version: "5"
-      pattern: *development_pattern
+      version: ">=5"
+      versionFilterKind: semver
     sync:
       version: ">=5.3.0-0"
       versionFilterKind: semver
@@ -68,8 +68,8 @@ matrix:
       pattern: *ga_activemq_pattern
     share: *acs_ga_version_spec
     search-enterprise: &search_ent_ga_version_spec
-      version: "5"
-      pattern: *ga_hotfixes_pattern
+      version: "~5"
+      versionFilterKind: semver
     sync: &sync_ga_version_spec
       version: "~5.3"
       versionFilterKind: semver

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -19,7 +19,7 @@ matrix:
       pattern: *ga_activemq_pattern
     share: *acs_next_version_spec
     search-enterprise:
-      version: ">=5"
+      version: ">=5.0.0-0"
       versionFilterKind: semver
     sync:
       version: ">=5.3.0-0"


### PR DESCRIPTION
Updates the supported-matrix to use semantic versioning for search-enterprise version constraints instead of pattern-based matching.

**Changes:**
- Next version: `version: "5"` with `pattern: *development_pattern` → `version: ">=5"` with `versionFilterKind: semver`
- Current version: `version: "5"` with `pattern: *ga_hotfixes_pattern` → `version: "~5"` with `versionFilterKind: semver`

This ensures consistent and more predictable version constraint evaluation for search-enterprise across different release channels.

OPSEXP-4102