### PR TITLE
OPSEXP-4221 Add Batch Indexing component support

### DIFF
--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -112,6 +112,17 @@ sources:
     spec:
       {{ template "common_version_filter" . }}
   {{ end }}
+  {{- with index . "batch-indexing" }}
+  batchIndexingTag_{{ $id }}:
+    name: Alfresco Elasticsearch Batch Indexing image tag
+    kind: dockerimage
+    spec:
+      image: {{ .image }}
+      {{ if eq (printf "%.8s" .image) "quay.io/" }}
+      {{ template "quay_auth" }}
+      {{ end }}
+      {{ template "common_version_filter" . }}
+  {{- end }}
   {{- with .search }}
   {{ $search_image := .image | default $default_search_image }}
   searchTag_{{ $id }}:
@@ -516,6 +527,39 @@ targets:
       file: {{ osDir $target_searchEnt }}/Chart.yaml
       key: "$.appVersion"
   {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- with index . "batch-indexing" }}
+  {{- if and .compose_key .compose_target }}
+  batchIndexingCompose_{{ $id }}:
+    name: Alfresco Elasticsearch Batch Indexing image tag
+    kind: yaml
+    sourceid: batchIndexingTag_{{ $id }}
+    transformers:
+      - addprefix: "{{ .image }}:"
+    spec:
+      file: {{ .compose_target }}
+      key: >-
+        {{ .compose_key }}
+  {{- end }}
+  {{- if and .helm_key .helm_target }}
+  batchIndexingValues_{{ $id }}:
+    name: Alfresco Elasticsearch Batch Indexing image tag
+    kind: yaml
+    sourceid: batchIndexingTag_{{ $id }}
+    spec:
+      file: {{ .helm_target }}
+      key: >-
+        {{ .helm_key }}
+  {{- end }}
+  {{- if .helm_update_appVersion }}
+  batchIndexingAppVersion_{{ $id }}:
+    name: Alfresco Elasticsearch Batch Indexing appVersion in Chart.yaml
+    kind: yaml
+    sourceid: batchIndexingTag_{{ $id }}
+    spec:
+      file: {{ osDir .helm_target }}/Chart.yaml
+      key: "$.appVersion"
   {{- end }}
   {{- end }}
   {{- with .share }}

--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -195,6 +195,10 @@ matrix:
     search:
       <<: *search_ga_version_spec
       image: docker.io/alfresco/alfresco-search-services
+    batch-indexing:
+      version: ">=5.0.0"
+      versionFilterKind: semver
+      image: docker.io/alfresco/alfresco-elasticsearch-batch-indexing
     adminApp: *acc_ga_version_spec
     tengine-aio: *tengines_ga_version_spec
     pdf-renderer: *pdf_renderer_version


### PR DESCRIPTION
Adds the community Batch Indexing component (`alfresco-elasticsearch-batch-indexing`) to `alfresco-updatecli` so its image tag is kept up to date automatically alongside the other Alfresco components.

## Changes

- Added `batch-indexing` to the `community` stream in `deployments/values/supported-matrix.yaml`, pinned to `docker.io/alfresco/alfresco-elasticsearch-batch-indexing` with a semver `>=5.0.0` constraint.
- Added the corresponding `batchIndexingTag` source and the `batchIndexingCompose` / `batchIndexingValues` / `batchIndexingAppVersion` targets in `deployments/uber-manifest.tpl`, following the existing per-component conventions (Helm values, compose target, and optional Chart.yaml appVersion updates gated on the consumer-supplied keys).

## Verification

The uber-manifest renders and `updatecli pipeline diff` runs without errors for the community stream; the new source resolves to the latest matching tag (`5.7.0`). The remaining source failures in a local run are pre-existing quay.io images that require real registry credentials, unrelated to this change.

OPSEXP-4221