### PR TITLE
OPSEXP-4192 Remove search from community slot

### DIFF
--- a/deployments/values/supported-matrix.yaml
+++ b/deployments/values/supported-matrix.yaml
@@ -200,9 +200,6 @@ matrix:
     share:
       <<: *acs_ga_version_spec
       image: docker.io/alfresco/alfresco-share
-    search:
-      <<: *search_ga_version_spec
-      image: docker.io/alfresco/alfresco-search-services
     batch-indexing:
       version: ">=5.0.0"
       versionFilterKind: semver


### PR DESCRIPTION
## Summary

From ACS 26 onwards Search Services is no longer available for the community edition; the `alfresco-elasticsearch-batch-indexing` component (added in #97) already covers Elasticsearch indexing for that slot, so `search:` is now redundant there.

- Removed the `search:` entry from the `community` slot in `deployments/values/supported-matrix.yaml`.
- Enterprise slots (`next`, `current`, `25.N`, `23.N`) are unaffected — their `search`/`search-enterprise` entries are untouched.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `updatecli manifest show` renders the manifest with no `searchTag_com` source and confirms `batchIndexingTag_com` is unaffected

OPSEXP-4192