### PR TITLE
OPSEXP-4271 Source search-enterprise version from quay.io image tags instead of git tags

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,9 +20,9 @@ The matrix leans heavily on YAML anchors/aliases (`&name` / `*name`) to share a 
 
 **Important:** the template's `targets` reference keys that are deliberately *not* present in this repo's matrix — `compose_target`, `compose_key`, `helm_target`, `helm_key`, `helm_keys`, `compose_keys`, `helm_update_appVersion`. Those are supplied by the **consuming** repo's own values file, which is merged on top of `supported-matrix.yaml` at run time. In this repo the matrix only declares version discovery (`sources`); target blocks stay inert because those keys are absent. Do not add them here.
 
-## Registry auth and SCMs
+## Registry auth
 
-Most images live on `quay.io` and the template injects `QUAY_USERNAME`/`QUAY_PASSWORD` — it does this only when the image string starts with `quay.io/` (community images on `docker.io` need no auth, so a component overriding `image:` to a docker.io path skips auth automatically). Search Enterprise's source (`searchEnterpriseTag_*`) polls the `quay.io/alfresco/alfresco-elasticsearch-reindexing` image tags the same way — that image and the `search-enterprise` compose/Helm target images (`quay.io/alfresco/alfresco-elasticsearch-{reindexing,live-indexing,...}`) are all built and pushed with the same tag in the same CI release job of `Alfresco/alfresco-elasticsearch-connector`, so any one of them is a valid stand-in for version discovery. CIC Connector is the remaining exception: it is resolved from **git tags** of `Alfresco/alfresco-cic-connector` via the `cicConnector` GitHub SCM, which needs `UPDATECLI_GITHUB_TOKEN`.
+Most images live on `quay.io` and the template injects `QUAY_USERNAME`/`QUAY_PASSWORD` — it does this only when the image string starts with `quay.io/` (community images on `docker.io` need no auth, so a component overriding `image:` to a docker.io path skips auth automatically). For multi-image components (e.g. `search-enterprise`, `cic-connector`), the source polls just one sibling image's tags as a stand-in for the whole set — their release CI pushes all sibling images with the same tag in one job, so any one is a valid proxy. No component in this manifest currently needs a GitHub SCM or `UPDATECLI_GITHUB_TOKEN`.
 
 ## Validating changes
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ The matrix leans heavily on YAML anchors/aliases (`&name` / `*name`) to share a 
 
 ## Registry auth and SCMs
 
-Most images live on `quay.io` and the template injects `QUAY_USERNAME`/`QUAY_PASSWORD` — it does this only when the image string starts with `quay.io/` (community images on `docker.io` need no auth, so a component overriding `image:` to a docker.io path skips auth automatically). Search Enterprise is the exception: it is resolved from **git tags** of `Alfresco/alfresco-elasticsearch-connector` via the `searchEnterprise` GitHub SCM, which needs `UPDATECLI_GITHUB_TOKEN`.
+Most images live on `quay.io` and the template injects `QUAY_USERNAME`/`QUAY_PASSWORD` — it does this only when the image string starts with `quay.io/` (community images on `docker.io` need no auth, so a component overriding `image:` to a docker.io path skips auth automatically). Search Enterprise's source (`searchEnterpriseTag_*`) polls the `quay.io/alfresco/alfresco-elasticsearch-reindexing` image tags the same way — that image and the `search-enterprise` compose/Helm target images (`quay.io/alfresco/alfresco-elasticsearch-{reindexing,live-indexing,...}`) are all built and pushed with the same tag in the same CI release job of `Alfresco/alfresco-elasticsearch-connector`, so any one of them is a valid stand-in for version discovery. CIC Connector is the remaining exception: it is resolved from **git tags** of `Alfresco/alfresco-cic-connector` via the `cicConnector` GitHub SCM, which needs `UPDATECLI_GITHUB_TOKEN`.
 
 ## Validating changes
 

--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -23,16 +23,6 @@
 name: {{ template "manifest_name" . }}
 
 scms:
-  searchEnterprise:
-    name: Alfresco Elasticsearch connector
-    kind: github
-    spec:
-      owner: Alfresco
-      repository: alfresco-elasticsearch-connector
-      branch: master
-      username: alfresco-build
-      token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-      directory: /tmp/updatecli/searchEnterprise
   cicConnector:
     name: Alfresco CIC Connector
     kind: github
@@ -117,9 +107,10 @@ sources:
   {{- with index . "search-enterprise" }}
   searchEnterpriseTag_{{ $id }}:
     name: Search Enterprise tag
-    kind: gittag
-    scmid: searchEnterprise
+    kind: dockerimage
     spec:
+      image: quay.io/alfresco/alfresco-elasticsearch-reindexing
+      {{ template "quay_auth" }}
       {{ template "common_version_filter" . }}
   {{ end }}
   {{- with index . "cic-connector" }}

--- a/deployments/uber-manifest.tpl
+++ b/deployments/uber-manifest.tpl
@@ -22,18 +22,6 @@
 ---
 name: {{ template "manifest_name" . }}
 
-scms:
-  cicConnector:
-    name: Alfresco CIC Connector
-    kind: github
-    spec:
-      owner: Alfresco
-      repository: alfresco-cic-connector
-      branch: master
-      username: alfresco-build
-      token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-      directory: /tmp/updatecli/cicConnector
-
 {{- $default_repo_image := "quay.io/alfresco/alfresco-content-repository" }}
 {{- $default_search_image := "quay.io/alfresco/search-services" }}
 {{- $default_share_image := "quay.io/alfresco/alfresco-share" }}
@@ -116,9 +104,10 @@ sources:
   {{- with index . "cic-connector" }}
   cicConnectorTag_{{ $id }}:
     name: CIC Connector tag
-    kind: gittag
-    scmid: cicConnector
+    kind: dockerimage
     spec:
+      image: quay.io/alfresco/alfresco-cic-connector-live-ingester
+      {{ template "quay_auth" }}
       {{ template "common_version_filter" . }}
   {{ end }}
   {{- with index . "batch-indexing" }}


### PR DESCRIPTION
## Summary

`search-enterprise` and `cic-connector` were the only components sourced via `gittag` SCMs against private GitHub repos (`Alfresco/alfresco-elasticsearch-connector`, `Alfresco/alfresco-cic-connector`, needing `UPDATECLI_GITHUB_TOKEN`), instead of a plain `dockerimage` source like every other component in this manifest.

Digging into both repos' release pipelines shows every image they produce is built and pushed with the exact same tag as the git release tag, in the same CI job — so any one sibling image is a valid stand-in for version discovery:

- `alfresco-elasticsearch-connector`: `.github/workflows/ci.yml` job `deploy_release_version_to_quay_and_docker_hub` + `scripts/ci/releaseDockerImage.sh` tag `quay.io/alfresco/alfresco-elasticsearch-{reindexing,live-indexing}` and the `docker.io` `alfresco-elasticsearch-batch-indexing` image identically.
- `alfresco-cic-connector`: `.github/workflows/ci.yml` job `deploy_release_version_to_quay` + `scripts/ci/releaseDockerImage.sh` tag `quay.io/alfresco/alfresco-cic-connector-{live-ingester,bulk-ingester,nucleus-sync}` identically, matching the git release tag set by the same job's `-Dtag=` maven-release-plugin call.

Changes:

- Switched `searchEnterpriseTag_{id}` from `kind: gittag`/`scmid: searchEnterprise` to `kind: dockerimage` against `quay.io/alfresco/alfresco-elasticsearch-reindexing`.
- Switched `cicConnectorTag_{id}` from `kind: gittag`/`scmid: cicConnector` to `kind: dockerimage` against `quay.io/alfresco/alfresco-cic-connector-live-ingester`.
- Both reuse the existing `quay_auth` template already used by every other quay-hosted component.
- Dropped the now-unused `searchEnterprise` and `cicConnector` GitHub SCM blocks, and the whole `scms:` section since nothing references it anymore. `UPDATECLI_GITHUB_TOKEN` is no longer needed by this manifest.
- Updated `.github/copilot-instructions.md`'s registry-auth section to describe the general multi-image-component pattern instead of enumerating each exception.

`versionFilter` semantics (regex/semver/regex-semver) are unchanged — `common_version_filter` is agnostic to source kind, so filtering behavior for `next`/`current`/`25.N`/`23.N` is identical to before.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `updatecli manifest show` renders cleanly; `searchEnterpriseTag_{next,current,25n,23n}` and `cicConnectorTag_{next,current,25n,23n}` all resolve to `kind: dockerimage` against their respective quay images with auth populated
- [x] tested live on https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/runs/30927529606


OPSEXP-4271