### PR TITLE
OPSEXP-4192 Add README with list of consuming repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ See `.github/copilot-instructions.md` for how the manifest and matrix fit togeth
 
 ## Consumers
 
-Repos in the `Alfresco` org known to consume this manifest:
+Public repos in the `Alfresco` org known to consume this manifest:
 
 - [acs-deployment](https://github.com/Alfresco/acs-deployment)
 - [alfresco-ansible-deployment](https://github.com/Alfresco/alfresco-ansible-deployment)
 - [alfresco-helm-charts](https://github.com/Alfresco/alfresco-helm-charts)
 - [alfresco-dockerfiles-bakery](https://github.com/Alfresco/alfresco-dockerfiles-bakery)
-- [alfresco-process-services-deployment](https://github.com/Alfresco/alfresco-process-services-deployment)
-- [flux-alfresco-pipeline](https://github.com/Alfresco/flux-alfresco-pipeline)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# alfresco-updatecli
+
+Shared source of truth for which Alfresco component versions are supported per ACS release line, expressed as an [updatecli](https://www.updatecli.io/) manifest. Downstream deployment repos consume `deployments/uber-manifest.tpl` and `deployments/values/supported-matrix.yaml` to automatically open PRs that bump image tags in their own compose/Helm files.
+
+See `.github/copilot-instructions.md` for how the manifest and matrix fit together and how to edit them.
+
+## Consumers
+
+Repos in the `Alfresco` org known to consume this manifest:
+
+- [acs-deployment](https://github.com/Alfresco/acs-deployment)
+- [alfresco-ansible-deployment](https://github.com/Alfresco/alfresco-ansible-deployment)
+- [alfresco-helm-charts](https://github.com/Alfresco/alfresco-helm-charts)
+- [alfresco-dockerfiles-bakery](https://github.com/Alfresco/alfresco-dockerfiles-bakery)
+- [alfresco-process-services-deployment](https://github.com/Alfresco/alfresco-process-services-deployment)
+- [flux-alfresco-pipeline](https://github.com/Alfresco/flux-alfresco-pipeline)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alfresco-updatecli
 
-Shared source of truth for which Alfresco component versions are supported per ACS release line, expressed as an [updatecli](https://www.updatecli.io/) manifest. Downstream deployment repos consume `deployments/uber-manifest.tpl` and `deployments/values/supported-matrix.yaml` to automatically open PRs that bump image tags in their own compose/Helm files.
+Shared source of truth for which Alfresco component versions are supported per ACS release line, expressed as an [updatecli](https://www.updatecli.io/) manifest. Downstream deployment repos consume [`deployments/uber-manifest.tpl`](deployments/uber-manifest.tpl) and [`deployments/values/supported-matrix.yaml`](deployments/values/supported-matrix.yaml) to automatically open PRs that bump image tags in their own compose/Helm files.
 
 See `.github/copilot-instructions.md` for how the manifest and matrix fit together and how to edit them.
 


### PR DESCRIPTION
## Summary
Adds a README.md with a brief overview of the repo's purpose and a "Consumers" section listing the Alfresco org repos that reference this manifest, found via `gh search code` for `alfresco-updatecli`, `supported-matrix.yaml`, and `uber-manifest` (all three converged on the same set of repos).

OPSEXP-4192